### PR TITLE
Fix EnTT includes for entity usage

### DIFF
--- a/include/IntersectionSystem.hpp
+++ b/include/IntersectionSystem.hpp
@@ -5,10 +5,9 @@
 #include <glm/glm.hpp>
 
 // --- FIX ---
-// Use the official EnTT forward-declaration header instead of a manual one
-// to prevent redefinition errors when this file is included alongside other
-// EnTT headers.
-#include "entt/entity/fwd.hpp"
+// Use the full EnTT entity header so that entt::entity and entt::null are
+// defined wherever this file is included.
+#include <entt/entity/entity.hpp>
 
 namespace IntersectionSystem
 {

--- a/include/ViewportWidget.hpp
+++ b/include/ViewportWidget.hpp
@@ -4,7 +4,7 @@
 #include <QOpenGLFunctions_3_3_Core>
 #include <QPoint>
 #include <memory>
-#include "entt/entity/fwd.hpp"
+#include <entt/entity/entity.hpp>
 #include <glm/glm.hpp>
 
 // Forward declarations


### PR DESCRIPTION
## Summary
- include the full EnTT entity header instead of `fwd.hpp`
- update IntersectionSystem comments

## Testing
- `cmake -S . -B build_test` *(fails: Could not find a package configuration file provided by "Qt6")*


------
https://chatgpt.com/codex/tasks/task_e_684e40329574832995c0f1e60ba010f8