### PR TITLE
Fix crash in ViewportWidget cleanup

### DIFF
--- a/include/ViewportWidget.hpp
+++ b/include/ViewportWidget.hpp
@@ -3,6 +3,7 @@
 #include <QOpenGLWidget>
 #include <QOpenGLFunctions_3_3_Core>
 #include <QOpenGLDebugLogger>
+#include <QMetaObject>
 #include <QPoint>
 #include <memory>
 #include <entt/entity/entity.hpp>
@@ -61,4 +62,7 @@ private:
 
     // Guard to ensure cleanupGL() is only executed once
     bool m_cleanedUp = false;
+
+    // Connection handle for context destruction
+    QMetaObject::Connection m_ctxDestroyConnection;
 };

--- a/src/ViewportWidget.cpp
+++ b/src/ViewportWidget.cpp
@@ -67,9 +67,8 @@ ViewportWidget::ViewportWidget(Scene* scene, entt::entity cameraEntity, QWidget*
 
 ViewportWidget::~ViewportWidget()
 {
-    if (QOpenGLContext* ctx = context())
-        disconnect(ctx, &QOpenGLContext::aboutToBeDestroyed,
-                   this, &ViewportWidget::cleanupGL);
+    if (m_ctxDestroyConnection)
+        QObject::disconnect(m_ctxDestroyConnection);
     cleanupGL();
 }
 
@@ -107,8 +106,9 @@ void ViewportWidget::initializeGL()
 
     // Ensure resources are released before the context goes away
     if (QOpenGLContext* ctx = context()) {
-        connect(ctx, &QOpenGLContext::aboutToBeDestroyed,
-                this, &ViewportWidget::cleanupGL, Qt::DirectConnection);
+        m_ctxDestroyConnection = connect(ctx, &QOpenGLContext::aboutToBeDestroyed,
+                                         this, &ViewportWidget::cleanupGL,
+                                         Qt::DirectConnection);
     }
 
     // Setup a debug logger if the context supports it


### PR DESCRIPTION
## Summary
- handle GL context destruction via stored connection
- disconnect safely in `ViewportWidget` destructor

## Testing
- `cmake --build build` *(fails: CMakeCache points to a different directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e68118b348329b00997849e669ff2